### PR TITLE
Fix Misspellings across .md files

### DIFF
--- a/_posts/2019-08-21-Using-Google-Translate-For-Internationalization.md
+++ b/_posts/2019-08-21-Using-Google-Translate-For-Internationalization.md
@@ -37,7 +37,7 @@ Getting an API Key from Google was a bit more difficult than expected. I strongl
 
 ### The Translate Button
 
-Clicking the translate buttion initiates the API call. All of the translation code happens inside the function:
+Clicking the translate button initiates the API call. All of the translation code happens inside the function:
 
 ```js
 $("#translateButton").click(function () {...}

--- a/_posts/2021-04-23-thank-you-and-goodbye.md
+++ b/_posts/2021-04-23-thank-you-and-goodbye.md
@@ -10,7 +10,7 @@ published: true
 
 # Thank you (and Goodbye)!
 
-I have been known to make short stories long. I won't do that here. Posting this message is my last offical act for the City.
+I have been known to make short stories long. I won't do that here. Posting this message is my last official act for the City.
 
 It has been a privilege beyond belief to serve Chicagoans, and it saddens me greatly to tell you I am leaving your official service. As a product of the social safety net of our fair town, this work has been a dream come true. But dreamers wake, and owe it to themselves to see reality as it is, not as they wish it were.
 

--- a/changelog.md
+++ b/changelog.md
@@ -35,7 +35,7 @@ _Beginning in February, changelog will be updated on Thursdays._
 
 #### 2020-02-20, 2-27 Thursday
 
-* Cranking away for launch. Policy & Strategery.
+* Cranking away for launch. Policy & Strategy.
 
 #### 2020-02-13 Thursday
 
@@ -62,7 +62,7 @@ _Beginning in February, changelog will be updated on Thursdays._
 * Design support for launch of the Chicago Design System. Launch upcoming.
 * Finished presentation for Config, the first Figma conference. Very excited.
 * Worked with 311 and OEMC on logo lockups for new print and social designs they have coming out. Rad!
-* In progress on producing an overaall viewpoint for our teams (AIS) to use in responding to branding questions from departments.
+* In progress on producing an overall viewpoint for our teams (AIS) to use in responding to branding questions from departments.
 
 
 

--- a/start.md
+++ b/start.md
@@ -19,7 +19,7 @@ The Chicago Design System (CDS) is a guide to producing delightful information, 
 
 In addition, this is the first municipal design system built for the public and government use. This is a platform that allows people to express their personal, community, and civic pride in Chicago. It gives the City of Chicago clearer, more effective communications through a uniform identity people can recognize and trust.
 
-The design system is made up of elements ilke our public mark, our new civic typeface, colors, secondary type families, and internet widgets. It includes the mark, document template, interactive prototypes, and the code to make a website. There's also a set of recipes to use for human-centered design work on your project.
+The design system is made up of elements like our public mark, our new civic typeface, colors, secondary type families, and internet widgets. It includes the mark, document template, interactive prototypes, and the code to make a website. There's also a set of recipes to use for human-centered design work on your project.
 
 ## Everyone
 
@@ -53,12 +53,12 @@ Now, you can turn on all our municipal typefaces and design away:
 
 To make an actual, honest-to-goodness Chicago Star in your typesetting, turn on discretionary ligatures in your app or CSS, and then type CHISTAR (in all caps). It’ll automatically replace with the star, sized correctly to fit the text.
 
-<p>Now, you can make ASCII art, or get tatooed with exactly the right Chicago Star.</p>
+<p>Now, you can make ASCII art, or get tattooed with exactly the right Chicago Star.</p>
 <p>=======</p>
 <p class="chistar">CHISTAR CHISTAR CHISTAR CHISTAR</p>
 <p>=======</p>
 
-If that didn't work, these images show the difference betweeen turning ligatures on and off. In this case, in Figma.
+If that didn't work, these images show the difference between turning ligatures on and off. In this case, in Figma.
 
 ![](/assets/img/CHISTAR-1.png)
 _Ligatures off, CHISTAR._


### PR DESCRIPTION
## Summary
Fix several misspellings across .md files and _posts.

## Changes
`buttion` -> `button`
`offical` -> `official`
`Strategery` -> `Strategy`
`overaall` -> `overall`
`ilke` -> `like`
`tatooed` -> `tattooed`
`betweeen` -> `between`